### PR TITLE
mw-feat-ImportFonts-29 Added code for importing Google Fonts Poppins …

### DIFF
--- a/src/styles/custom.scss
+++ b/src/styles/custom.scss
@@ -18,17 +18,34 @@ $platinum: #ecebea;
 // @import "./checkbox.scss";
 //some other examples: https://github.com/brendalong/christmas-list/blob/main/src/scss/custom.scss
 
+// Import Google Fonts
+// font-family: 'Poppins', sans-serif;
+// font-family: 'Space Mono', monospace;
+@import url('https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,700;1,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,700;1,400;1,700&family=Space+Mono:ital,wght@0,700;1,700&display=swap');
+
 //Main styling =========================
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Poppins", "Space Mono",
-    "Roboto", "Fira Sans", sans-serif;
+  font-family: "Poppins", sans-serif;
+  font-weight: normal;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
   font-family: monospace, sans-serif;
+}
+
+// Text
+h1, h2 {
+  font-family: "Space Mono";
+  font-weight: bold;
+}
+
+h3,h4,h5,h6 {
+  font-family: "Poppins", sans-serif;
+  font-weight: bold;
 }
 
 // Header ===============================


### PR DESCRIPTION
#29 
…and Space Mono; coded CSS rules for the following elements body, p, h1,h2,h3,h4,h5,h6; checked that the fonts are being applied in the browser.

# Description Import Fonts to custom.scss

- Added code for importing Google Fonts Poppins and Space Mono;
- coded CSS rules for the following elements body, p, h1,h2,h3,h4,h5,h6; 
- checked that the fonts are being applied in the browser.

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Testing Instructions

1. Pull down branch
2. Run in browser
3. Open DevTools/Inspect on any h1 or h2 to confirm the font-family is Space Mono
4. Inspect h3,h3,h4,h5,h6 to confirm the font-family is Poppins with font-weight bold
5. Inspect any text on page that is not text from 3-4 items to confirm the font-family is Poppins with font-weight normal

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works