### PR TITLE
mw-update-MichaelWright-portfolio-link update Michael Wright's portfo…

### DIFF
--- a/public/api/database.json
+++ b/public/api/database.json
@@ -447,7 +447,7 @@
       "email": "mrwry7@gmail.com",
       "git": "https://github.com/sm3dev",
       "linkedin": "https://www.linkedin.com/in/mpw/",
-      "personal": "https://www.michaelpwright.com/",
+      "personal": "https://sm3dev.github.io/michaelpwright-portfolio/",
       "fact": "I think the letter “W” should be called “wuh”",
       "capName": "Smilestones",
       "capLink": "#",

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,10 +2,10 @@
 
 ## Type of change
 
-- [] Bug fix (non-breaking change which fixes an issue)
-- [] New feature (non-breaking change which adds functionality)
-- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [] This change requires a documentation update
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
 
 # Testing Instructions
 
@@ -16,8 +16,8 @@ Added styling to fall in-line with existing buttons.
 
 # Checklist:
 
-- [] My code follows the style guidelines of this project
-- [] I have performed a self-review of my own code
-- [] I have commented my code, particularly in hard-to-understand areas
-- [] My changes generate no new warnings or errors
-- [] I have added test instructions that prove my fix is effective or that my feature works
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no new warnings or errors
+- [ ] I have added test instructions that prove my fix is effective or that my feature works


### PR DESCRIPTION
# Description
- Updated student Michael Wright's (me) portfolio link.
- Updated the Markdown Checkboxes in the pull_request_template.md; the checkboxes need a space between the brackets in order to be 'checkable' in a browser. 

## Type of change

- [x] This change requires a documentation update

# Testing Instructions
- Pull down the branch and serve the website in the browser using `npm start`
- Find the student card for **Michael Wright** and click **Portfolio**: the link should take you to the website address https://sm3dev.github.io/michaelpwright-portfolio/
- To test that the PR Template has checkable buttons now, you'll have to create a new Pull Request...actually, the checkable boxes should show inside this box you're reading right now 🤔🤔

ADDITION:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works